### PR TITLE
modify pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
                 <version>1.1</version>
                 <executions>
                     <execution>
-                        <phase>compile</phase>
+                        <phase>test</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>


### PR DESCRIPTION
compile phase => test phase

correct eclipse following error:

Plugin execution not covered by lifecycle configuration: org.apache.maven.plugins:maven-antrun-plugin:1.1:run (execution: default, phase: compile)  
pom.xml 
/ErRabbitServer line 179  
Maven Project Build Lifecycle Mapping Problem
