### PR TITLE
squid:S2293 - The diamond operator ("<>") should be used

### DIFF
--- a/src/main/java/org/mintcode/errabbit/controller/console/LogController.java
+++ b/src/main/java/org/mintcode/errabbit/controller/console/LogController.java
@@ -84,7 +84,7 @@ public class LogController {
 
             // Get first day of report
             LogLevelDailyStatistics firstDayStatistic = logLevelDailyStatisticsRepository.findByRabbitIdOnFirst(id);
-            List<Integer> yearList = new ArrayList<Integer>();
+            List<Integer> yearList = new ArrayList<>();
             if (firstDayStatistic != null){
 
                 // Today
@@ -167,7 +167,7 @@ public class LogController {
 
             // Make Calendar with blank cell
             int lastDayOfMonth = DateUtil.getLastDayOfMonth(year, month);
-            List<DayCell> cellList = new ArrayList<DayCell>();
+            List<DayCell> cellList = new ArrayList<>();
             for (int i=0 ; i < lastDayOfMonth; i++){
                 cellList.add(new DayCell(i+1));
             }

--- a/src/main/java/org/mintcode/errabbit/core/analysis/AggregationAnalyzer.java
+++ b/src/main/java/org/mintcode/errabbit/core/analysis/AggregationAnalyzer.java
@@ -24,7 +24,7 @@ public class AggregationAnalyzer {
     MongoTemplate mongoTemplate;
 
     // TypeToken for aggregating result type
-    private final HashMap<String,Object> mapType = new HashMap<String,Object>();
+    private final HashMap<String,Object> mapType = new HashMap<>();
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     /**

--- a/src/main/java/org/mintcode/errabbit/core/console/ReportPresentation.java
+++ b/src/main/java/org/mintcode/errabbit/core/console/ReportPresentation.java
@@ -28,7 +28,7 @@ public class ReportPresentation {
      * @return
      */
     public Map<Log,List<StackTraceGraph>> makeTraceGraph(String basePackage, Page<Log> reportPage){
-        Map<Log,List<StackTraceGraph>> graphs = new HashMap<Log, List<StackTraceGraph>>();
+        Map<Log,List<StackTraceGraph>> graphs = new HashMap<>();
         for (Log log : reportPage.getContent()){
             graphs.put(log, makeTraceGraph(basePackage, log));
         }
@@ -47,7 +47,7 @@ public class ReportPresentation {
                 return null;
             }
 
-            List<StackTraceGraph> graphs = new ArrayList<StackTraceGraph>();
+            List<StackTraceGraph> graphs = new ArrayList<>();
 
             StackTraceGraph lastGraph = new StackTraceGraph(basePackage);
             graphs.add(lastGraph);

--- a/src/main/java/org/mintcode/errabbit/core/console/StackTraceGraph.java
+++ b/src/main/java/org/mintcode/errabbit/core/console/StackTraceGraph.java
@@ -13,7 +13,7 @@ import java.util.List;
  */
 public class StackTraceGraph {
 
-    private List<ErStackTraceElement> stackTraceElements = new ArrayList<ErStackTraceElement>();
+    private List<ErStackTraceElement> stackTraceElements = new ArrayList<>();
     private String basePackage;
     private String className;
     private String packageName;

--- a/src/main/java/org/mintcode/errabbit/core/rabbit/name/InMemoryRabbitCache.java
+++ b/src/main/java/org/mintcode/errabbit/core/rabbit/name/InMemoryRabbitCache.java
@@ -48,7 +48,7 @@ public class InMemoryRabbitCache implements RabbitCache {
     }
 
     public List<Rabbit> getRabbits() {
-        return new ArrayList<Rabbit>(rabbits.values());
+        return new ArrayList<>(rabbits.values());
     }
 
     public void syncDailyStatistics() {

--- a/src/main/java/org/mintcode/errabbit/model/Graph.java
+++ b/src/main/java/org/mintcode/errabbit/model/Graph.java
@@ -45,7 +45,7 @@ public class Graph {
      */
     public Map<Integer, Integer> getTimeLine(String level){
         if (!data.containsKey(level)){
-            Map<Integer, Integer> timeLine = new HashMap<Integer, Integer>();
+            Map<Integer, Integer> timeLine = new HashMap<>();
             for (int h=0 ; h <24; h++){
                 timeLine.put(h, 0); // set zero counts
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2293 - The diamond operator ("<>") should be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
George Kankava
