### PR TITLE
Multiple code improvements - squid:LowerCaseLongSuffixCheck, squid:S1854, squid:CommentedOutCodeLine

### DIFF
--- a/src/main/java/org/mintcode/errabbit/controller/console/EventController.java
+++ b/src/main/java/org/mintcode/errabbit/controller/console/EventController.java
@@ -107,8 +107,8 @@ public class EventController {
     ) {
 
         try{
-            EventMapping mapping = null;
-            EventCondition condition = null;
+            EventMapping mapping;
+            EventCondition condition;
             if (id == null){
                 mapping = new EventMapping();
                 condition = new EventCondition();

--- a/src/main/java/org/mintcode/errabbit/controller/console/LoginController.java
+++ b/src/main/java/org/mintcode/errabbit/controller/console/LoginController.java
@@ -12,8 +12,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Controller
 public class LoginController {
 
-//    private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
     @RequestMapping(value = "/login")
     public String login(Model model,
                              @RequestParam(value = "error", required = false) String error,

--- a/src/main/java/org/mintcode/errabbit/core/eventstream/event/EventChecker.java
+++ b/src/main/java/org/mintcode/errabbit/core/eventstream/event/EventChecker.java
@@ -26,9 +26,9 @@ public class EventChecker implements Comparable{
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     // Count for matched
-    private Long metricMatched = 0l;
+    private Long metricMatched = 0L;
     // Count for matched but ignored by sleeping status
-    private Long metricIgnoreFromSleepSec = 0l;
+    private Long metricIgnoreFromSleepSec = 0L;
 
     private EventStream eventStream;
 
@@ -84,10 +84,6 @@ public class EventChecker implements Comparable{
         int l1v = convertLevelValue(l1);
         int l2v = convertLevelValue(l2);
         return (l1v <= l2v);
-
-//        Level level1 = Level.getLevel(l1);
-//        Level level2 = Level.getLevel(l2);
-//        return level1.isLessSpecificThan(level2);
     }
 
     protected int convertLevelValue(String l){


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:LowerCaseLongSuffixCheck - Long suffix "L" should be upper case.
squid:S1854 - Dead stores should be removed.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:LowerCaseLongSuffixCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
Please let me know if you have any questions.
George Kankava
