### PR TITLE
Multiple code improvements - squid:UselessParenthesesCheck, squid:S1854, squid:S1488

### DIFF
--- a/src/main/java/org/mintcode/errabbit/core/collect/LogBuffer.java
+++ b/src/main/java/org/mintcode/errabbit/core/collect/LogBuffer.java
@@ -99,7 +99,7 @@ public class LogBuffer {
 
             // Hour
             String key = log.getRabbitId()  +"/"  + log.getLoggingEventDateInt() + "/" + cal.get(Calendar.HOUR_OF_DAY);
-            Map<String,Object> hour = null;
+            Map<String,Object> hour;
             if (hours.containsKey(key)){
                 hour = hours.get(key);
             }

--- a/src/main/java/org/mintcode/errabbit/core/collect/parser/impl/PythonLogDeserializer.java
+++ b/src/main/java/org/mintcode/errabbit/core/collect/parser/impl/PythonLogDeserializer.java
@@ -84,7 +84,7 @@ public class PythonLogDeserializer implements JsonDeserializer<ErrLoggingEvent> 
      * @return
      */
     protected String getFilename(String filePath){
-        String simbol = null;
+        String simbol;
         if (filePath.contains("/")) // Unix
             simbol = "/";
         else {

--- a/src/main/java/org/mintcode/errabbit/core/eventstream/event/EventChecker.java
+++ b/src/main/java/org/mintcode/errabbit/core/eventstream/event/EventChecker.java
@@ -83,7 +83,7 @@ public class EventChecker implements Comparable{
 
         int l1v = convertLevelValue(l1);
         int l2v = convertLevelValue(l2);
-        return (l1v <= l2v);
+        return l1v <= l2v;
     }
 
     protected int convertLevelValue(String l){

--- a/src/main/java/org/mintcode/errabbit/core/eventstream/stream/AbstractEventStream.java
+++ b/src/main/java/org/mintcode/errabbit/core/eventstream/stream/AbstractEventStream.java
@@ -74,8 +74,7 @@ public abstract class AbstractEventStream implements EventStream {
 
     public String makeDescription(){
         Gson gson = new Gson();
-        String json = gson.toJson(eventCheckers);
-        return json;
+        return gson.toJson(eventCheckers);
     }
 
     public Set<EventChecker> getEventCheckers() {

--- a/src/main/java/org/mintcode/errabbit/core/rabbit/managing/RabbitManagingServiceImpl.java
+++ b/src/main/java/org/mintcode/errabbit/core/rabbit/managing/RabbitManagingServiceImpl.java
@@ -153,7 +153,7 @@ public class RabbitManagingServiceImpl implements RabbitManagingService {
         }
         for (Rabbit r : rabbits){
             RabbitGroup group = r.getGroup();
-            Set<Rabbit> set = null;
+            Set<Rabbit> set;
             if (map.containsKey(group)){
                 set =  map.get(group);
             }

--- a/src/main/java/org/mintcode/errabbit/model/Log.java
+++ b/src/main/java/org/mintcode/errabbit/model/Log.java
@@ -168,10 +168,10 @@ public class Log implements Serializable {
         SimpleDateFormat format = new SimpleDateFormat("HH:mm:ss:SSS");
         StringBuilder sb = new StringBuilder();
         sb.append(String.format("<li class='log' data-e='%s' data-poload='/log/popover_data?id=%s'>",
-                (loggingEvent.getThrowableInfo() != null ? "true" : "") ,id.toString()));
+                loggingEvent.getThrowableInfo() != null ? "true" : "" ,id.toString()));
             sb.append(String.format("<span class='time' data-toggle='popover' data-placement='right' data-trigger='hover' title='Application time' data-content='Server collecting time : %s'>%s</span>", format.format(collectedDate), format.format(loggingEvent.timeStampDate)));
             sb.append(String.format("<span class='level %s %s' data-url='%s'>%s</span>", loggingEvent.level,
-                                                                (loggingEvent.getThrowableInfo() != null ? "has_exception" : ""),
+                                                                loggingEvent.getThrowableInfo() != null ? "has_exception" : "",
                                                                 filterlevelURL,
                                                                 loggingEvent.level));
             sb.append("<div class='contgroup'>");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1854 - Dead stores should be removed.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1488
Please let me know if you have any questions.
George Kankava
