### PR TITLE
Multiple code improvements - squid:RedundantThrowsDeclarationCheck, squid:S1213, squid:S2864

### DIFF
--- a/src/main/java/org/mintcode/errabbit/core/collect/LogBuffer.java
+++ b/src/main/java/org/mintcode/errabbit/core/collect/LogBuffer.java
@@ -129,13 +129,13 @@ public class LogBuffer {
         for (Map<String,Object> hour : hours.values()){
             logLevelDailyStatisticsRepository.insertStatistic(hour);
             logLevelHourlyStatisticsRepository.insertStatistic(hour);
-            for (String key : hour.keySet()){
-                if (key.startsWith("level_")){
-                    String level = key.replaceAll("level_","");
+            for (Map.Entry<String, Object> entry : hour.entrySet()){
+                if (entry.getKey().startsWith("level_")){
+                    String level = entry.getKey().replaceAll("level_","");
                     rabbitCache.updateDailyStatistics((String) hour.get("rabbitId"),
                             level,
                             (Integer) hour.get("dateInt"),
-                            (Integer) hour.get(key));
+                            (Integer) entry.getValue());
                 }
             }
         }

--- a/src/main/java/org/mintcode/errabbit/core/collect/parser/impl/PythonLogDeserializer.java
+++ b/src/main/java/org/mintcode/errabbit/core/collect/parser/impl/PythonLogDeserializer.java
@@ -19,7 +19,7 @@ import java.util.Date;
 public class PythonLogDeserializer implements JsonDeserializer<ErrLoggingEvent> {
 
     @Override
-    public ErrLoggingEvent deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+    public ErrLoggingEvent deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) {
 
         JsonObject log = (JsonObject) jsonElement;
         ErrLoggingEvent ee = new ErrLoggingEvent();

--- a/src/main/java/org/mintcode/errabbit/core/eventstream/event/EventMapping.java
+++ b/src/main/java/org/mintcode/errabbit/core/eventstream/event/EventMapping.java
@@ -29,6 +29,14 @@ public class EventMapping {
 
     private String name;
 
+    public EventMapping(){
+
+    }
+
+    public EventMapping(EventCondition condition) {
+        this.condition = condition;
+    }
+
     public String getId() {
         return id;
     }
@@ -37,20 +45,12 @@ public class EventMapping {
         this.id = id;
     }
 
-    public EventMapping(){
-
-    }
-
     public String getName() {
         return name;
     }
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public EventMapping(EventCondition condition) {
-        this.condition = condition;
     }
 
     public void addEventAction(EventAction action){

--- a/src/main/java/org/mintcode/errabbit/core/log/dao/LogLevelDailyStatisticsRepositoryImpl.java
+++ b/src/main/java/org/mintcode/errabbit/core/log/dao/LogLevelDailyStatisticsRepositoryImpl.java
@@ -66,9 +66,9 @@ public class LogLevelDailyStatisticsRepositoryImpl implements LogLevelDailyStati
             q.put("day", day);
 
             DBObject u = new BasicDBObject();
-            for (String key : staticSet.keySet()){
-                if (key.startsWith("level_")){
-                    u.put("$inc", new BasicDBObject(key, staticSet.get(key)));
+            for (Map.Entry<String, Object> entry : staticSet.entrySet()){
+                if (entry.getKey().startsWith("level_")){
+                    u.put("$inc", new BasicDBObject(entry.getKey(), entry.getValue()));
                 }
             }
             coll.update(q, u, true, false);

--- a/src/main/java/org/mintcode/errabbit/core/log/dao/LogLevelHourlyStatisticsRepositoryImpl.java
+++ b/src/main/java/org/mintcode/errabbit/core/log/dao/LogLevelHourlyStatisticsRepositoryImpl.java
@@ -66,9 +66,9 @@ public class LogLevelHourlyStatisticsRepositoryImpl implements LogLevelHourlySta
             q.put("hour", hour);
 
             DBObject u = new BasicDBObject();
-            for (String key : staticSet.keySet()){
-                if (key.startsWith("level_")){
-                    u.put("$inc", new BasicDBObject(key, staticSet.get(key)));
+            for (Map.Entry<String, Object> entry : staticSet.entrySet()){
+                if (entry.getKey().startsWith("level_")){
+                    u.put("$inc", new BasicDBObject(entry.getKey(), entry.getValue()));
                 }
             }
             coll.update(q, u, true, false);

--- a/src/main/java/org/mintcode/errabbit/core/rabbit/managing/RabbitManagingServiceImpl.java
+++ b/src/main/java/org/mintcode/errabbit/core/rabbit/managing/RabbitManagingServiceImpl.java
@@ -176,10 +176,10 @@ public class RabbitManagingServiceImpl implements RabbitManagingService {
             rabbitGroupSetMap = getRabbitsByGroup();
         }
         List<RabbitGroup> list = new ArrayList<>();
-        for (RabbitGroup r : rabbitGroupSetMap.keySet()){
-            r.setRabbits(new ArrayList<>(rabbitGroupSetMap.get(r)));
-            list.add(r);
-            Collections.sort(r.getRabbits(), rabbitNameComparator);
+        for (Map.Entry<RabbitGroup, Set<Rabbit>> entry : rabbitGroupSetMap.entrySet()){
+            entry.getKey().setRabbits(new ArrayList<>(entry.getValue()));
+            list.add(entry.getKey());
+            Collections.sort(entry.getKey().getRabbits(), rabbitNameComparator);
         }
         Collections.sort(list, rabbitGroupNameComparator);
         return list;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:RedundantThrowsDeclarationCheck - Throws declarations should not be superfluous.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:RedundantThrowsDeclarationCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S2864
Please let me know if you have any questions.
George Kankava
