### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/org/mintcode/errabbit/model/ErrLoggingEvent.java
+++ b/src/main/java/org/mintcode/errabbit/model/ErrLoggingEvent.java
@@ -16,6 +16,22 @@ public class ErrLoggingEvent implements Serializable{
 
     private static final long serialVersionUID = 1L;
 
+    public String categoryName;
+
+    public String level;
+
+    private String renderedMessage;
+
+    private String threadName;
+
+    private ErLocationInfo locationInfo;
+
+    private ErThrowableInformation throwableInfo;
+
+    public long timeStamp;
+
+    public Date timeStampDate;
+
     public ErrLoggingEvent(){
 
     }
@@ -65,22 +81,6 @@ public class ErrLoggingEvent implements Serializable{
 
         return erLoggingEvent;
     }
-
-    public String categoryName;
-
-    public String level;
-
-    private String renderedMessage;
-
-    private String threadName;
-
-    private ErLocationInfo locationInfo;
-
-    private ErThrowableInformation throwableInfo;
-
-    public long timeStamp;
-
-    public Date timeStampDate;
 
     public String getCategoryName() {
         return categoryName;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava
