### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/org/mintcode/errabbit/core/analysis/result/AnalysisResultSet.java
+++ b/src/main/java/org/mintcode/errabbit/core/analysis/result/AnalysisResultSet.java
@@ -29,14 +29,6 @@ public class AnalysisResultSet implements Serializable {
     }
 
     /**
-     * Set result
-     * @param results
-     */
-    public void setResults(Map<String, AnalysisResult> results) {
-        this.results = results;
-    }
-
-    /**
      * initation with result
      * @param req
      * @param result
@@ -45,6 +37,14 @@ public class AnalysisResultSet implements Serializable {
         logger.trace("result > " + result);
         results.put(TABLE, new TableLogAnalysisResult(req, result));
         results.put(GRAPHIC, new GraphicLogAnalysisResult(req, result));
+    }
+
+    /**
+     * Set result
+     * @param results
+     */
+    public void setResults(Map<String, AnalysisResult> results) {
+        this.results = results;
     }
 
     /**

--- a/src/main/java/org/mintcode/errabbit/core/eventstream/event/action/EventActionUIElement.java
+++ b/src/main/java/org/mintcode/errabbit/core/eventstream/event/action/EventActionUIElement.java
@@ -13,6 +13,10 @@ public class EventActionUIElement {
     public Boolean isRequired = false;
     public Object value;
 
+    public EventActionUIElement(){
+
+    }
+
     public EventActionUIElement(String name, String label, String valueType, String defaultValue, String help, Boolean isRequired, Object value) {
         this.name = name;
         this.label = label;
@@ -69,10 +73,6 @@ public class EventActionUIElement {
 
     public void setRequired(Boolean required) {
         isRequired = required;
-    }
-
-    public EventActionUIElement(){
-
     }
 
     public Object getValue() {

--- a/src/main/java/org/mintcode/errabbit/core/report/ReportDescriptionTime.java
+++ b/src/main/java/org/mintcode/errabbit/core/report/ReportDescriptionTime.java
@@ -12,6 +12,14 @@ public class ReportDescriptionTime implements Serializable {
     private Integer hour;
 
     /**
+     * Construct with batch time hour
+     * @param hour
+     */
+    public ReportDescriptionTime(Integer hour) {
+        this.hour = hour;
+    }
+
+    /**
      * Batch time hour (24h)
      * @return
      */
@@ -24,14 +32,6 @@ public class ReportDescriptionTime implements Serializable {
      * @param hour
      */
     public void setHour(Integer hour) {
-        this.hour = hour;
-    }
-
-    /**
-     * Construct with batch time hour
-     * @param hour
-     */
-    public ReportDescriptionTime(Integer hour) {
         this.hour = hour;
     }
 }

--- a/src/main/java/org/mintcode/errabbit/model/ErLocationInfo.java
+++ b/src/main/java/org/mintcode/errabbit/model/ErLocationInfo.java
@@ -12,6 +12,23 @@ public class ErLocationInfo implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Caller's line number.
+     */
+    String lineNumber;
+    /**
+     * Caller's file name.
+     */
+    String fileName;
+    /**
+     * Caller's fully qualified class name.
+     */
+    String className;
+    /**
+     * Caller's method name.
+     */
+    String methodName;
+
     public ErLocationInfo() {
 
     }
@@ -32,23 +49,6 @@ public class ErLocationInfo implements Serializable {
 
         return erLocationInfo;
     }
-
-    /**
-     * Caller's line number.
-     */
-    String lineNumber;
-    /**
-     * Caller's file name.
-     */
-    String fileName;
-    /**
-     * Caller's fully qualified class name.
-     */
-    String className;
-    /**
-     * Caller's method name.
-     */
-    String methodName;
 
     /**
      * Get lineNumber

--- a/src/main/java/org/mintcode/errabbit/model/RabbitGroup.java
+++ b/src/main/java/org/mintcode/errabbit/model/RabbitGroup.java
@@ -29,14 +29,14 @@ public class RabbitGroup implements Serializable {
 
     }
 
-    // Get NoneGroup
-    public static RabbitGroup noneGroup(){
-        return new NoneRabbitGroup();
-    }
-
     // RabbitGroup with name
     public RabbitGroup(String name) {
         this.name = name;
+    }
+
+    // Get NoneGroup
+    public static RabbitGroup noneGroup(){
+        return new NoneRabbitGroup();
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava
