### PR TITLE
squid:S1148 - Throwable.printStackTrace(...) should not be called

### DIFF
--- a/src/main/java/org/mintcode/errabbit/controller/console/ConsoleController.java
+++ b/src/main/java/org/mintcode/errabbit/controller/console/ConsoleController.java
@@ -41,7 +41,6 @@ public class ConsoleController {
             return "/console/main";
         }
         catch (Exception e){
-            e.printStackTrace();
             logger.error(e.getMessage(),e);
             // todo: make ErrorPage
             model.addAttribute("e",e);

--- a/src/main/java/org/mintcode/errabbit/controller/console/LogController.java
+++ b/src/main/java/org/mintcode/errabbit/controller/console/LogController.java
@@ -190,7 +190,6 @@ public class LogController {
             return new ModelAndView("/log/day_data");
         }
         catch (Exception e){
-            e.printStackTrace();
             logger.error(e.getMessage(),e);
             // todo: make ErrorPage
             model.addAttribute("e",e);

--- a/src/main/java/org/mintcode/errabbit/core/log/dao/LogLevelDailyStatisticsRepositoryImpl.java
+++ b/src/main/java/org/mintcode/errabbit/core/log/dao/LogLevelDailyStatisticsRepositoryImpl.java
@@ -73,7 +73,6 @@ public class LogLevelDailyStatisticsRepositoryImpl implements LogLevelDailyStati
             }
             coll.update(q, u, true, false);
         } catch (Exception e) {
-            e.printStackTrace();
             logger.error(e.getMessage());
         }
     }
@@ -121,7 +120,6 @@ public class LogLevelDailyStatisticsRepositoryImpl implements LogLevelDailyStati
             u.put("$inc", new BasicDBObject("level_" + log.getLoggingEvent().getLevel(), 1));
             coll.update(q, u, true, false);
         } catch (Exception e) {
-            e.printStackTrace();
             logger.error(e.getMessage());
         }
     }

--- a/src/main/java/org/mintcode/errabbit/core/log/dao/LogLevelHourlyStatisticsRepositoryImpl.java
+++ b/src/main/java/org/mintcode/errabbit/core/log/dao/LogLevelHourlyStatisticsRepositoryImpl.java
@@ -73,7 +73,6 @@ public class LogLevelHourlyStatisticsRepositoryImpl implements LogLevelHourlySta
             }
             coll.update(q, u, true, false);
         } catch (Exception e) {
-            e.printStackTrace();
             logger.error(e.getMessage());
         }
     }
@@ -123,7 +122,6 @@ public class LogLevelHourlyStatisticsRepositoryImpl implements LogLevelHourlySta
             u.put("$inc", new BasicDBObject("level_" + log.getLoggingEvent().getLevel(), 1));
             coll.update(q, u, true, false);
         } catch (Exception e) {
-            e.printStackTrace();
             logger.error(e.getMessage());
         }
     }

--- a/src/main/java/org/mintcode/errabbit/core/log/dao/LogRepositoryImpl.java
+++ b/src/main/java/org/mintcode/errabbit/core/log/dao/LogRepositoryImpl.java
@@ -87,7 +87,6 @@ public class LogRepositoryImpl implements LogRepositoryCustom {
             mongoOperations.upsert(query, update, LogLevelHourStatistics.class);
 
         } catch (Exception e) {
-            e.printStackTrace();
             logger.error(e.getMessage());
         }
     }

--- a/src/main/java/org/mintcode/errabbit/model/ErThrowableInformation.java
+++ b/src/main/java/org/mintcode/errabbit/model/ErThrowableInformation.java
@@ -3,6 +3,8 @@ package org.mintcode.errabbit.model;
 import org.apache.log4j.Category;
 import org.apache.log4j.spi.ThrowableInformation;
 import org.apache.logging.log4j.core.impl.ThrowableProxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.lang.reflect.Field;
@@ -15,6 +17,8 @@ import java.util.Arrays;
  * Created by soleaf on 2/21/15.
  */
 public class ErThrowableInformation implements Serializable{
+
+    private static final Logger logger = LoggerFactory.getLogger(ErThrowableInformation.class);
 
     private static final long serialVersionUID = 1L;
 
@@ -40,9 +44,9 @@ public class ErThrowableInformation implements Serializable{
             field.setAccessible(true);
             ert.setCategory(ErCategory.fromCategory((Category) field.get(tw)));
         } catch (NoSuchFieldException e) {
-            e.printStackTrace();
+            logger.error(e.getMessage(), e);
         } catch (IllegalAccessException e) {
-            e.printStackTrace();
+            logger.error(e.getMessage(), e);
         }
 
         return ert;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1148 - Throwable.printStackTrace(...) should not be called.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1148
Please let me know if you have any questions.
George Kankava
