### PR TITLE
squid:S2275 - Printf-style format strings should not lead to unexpected behavior at runtime

### DIFF
--- a/src/main/java/org/mintcode/errabbit/core/eventstream/event/action/SlackNotificationEventAction.java
+++ b/src/main/java/org/mintcode/errabbit/core/eventstream/event/action/SlackNotificationEventAction.java
@@ -124,11 +124,11 @@ public class SlackNotificationEventAction extends AbstractEventAction {
     protected String generateMessage(Log log){
         ErrLoggingEvent ev = log.getLoggingEvent();
         if (host != null) {
-            return String.format("[ %s ] %s\n%s\n:mag: %s/log/list.err?id=%s",
+            return String.format("[ %s ] %s%n%s%n:mag: %s/log/list.err?id=%s",
                     ev.getLevel(), log.getRabbitId(), ev.getRenderedMessage(), host, log.getRabbitId());
         }
         else{
-            return String.format("[ %s ] %s\n%s",
+            return String.format("[ %s ] %s%n%s",
                     ev.getLevel(), log.getRabbitId(), ev.getRenderedMessage());
         }
     }

--- a/src/main/java/org/mintcode/errabbit/core/rabbit/managing/RabbitManagingServiceImpl.java
+++ b/src/main/java/org/mintcode/errabbit/core/rabbit/managing/RabbitManagingServiceImpl.java
@@ -75,16 +75,16 @@ public class RabbitManagingServiceImpl implements RabbitManagingService {
 
         // Rabbit Name Validation
         if (id == null){
-            throw new InvalidRabbitNameException(String.format("'Null' is invalid"));
+            throw new InvalidRabbitNameException("'Null' is invalid");
         }
         if (id.length() < 2){
-            throw new InvalidRabbitNameException(String.format("Rabbit id's length must be greater than 2 characters."));
+            throw new InvalidRabbitNameException("Rabbit id's length must be greater than 2 characters.");
         }
         if (id.contains(" ")){
-            throw new InvalidRabbitNameException(String.format("Rabbit id's should not include blank"));
+            throw new InvalidRabbitNameException("Rabbit id's should not include blank");
         }
         if (id.contains(",")){
-            throw new InvalidRabbitNameException(String.format("Rabbit id's should comma"));
+            throw new InvalidRabbitNameException("Rabbit id's should comma");
         }
 
         // Check already exist id


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S2275 - Printf-style format strings should not lead to unexpected behavior at runtime.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2275
Please let me know if you have any questions.
George Kankava
